### PR TITLE
add ResearchGate

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Please note that it is not encouraged to blindly apply to every company on this 
 | [Redfin](http://www.redfin.com/about/jobs) | San Francisco, CA; Seattle, WA |
 | [Redis-Labs](https://redislabs.com/company/redis-labs-careers) | Tel Aviv, Israel |
 | [Remitly](https://www.remitly.com/us/en/home/careers) | Seattle, WA |
+| [ResearchGate](https://www.researchgate.net/careers#positions) | Berlin, Germany |
 | [Resultados Digitais](http://resultadosdigitais.com.br/trabalhe-conosco/) | Florianópolis, SC, Brazil |
 | [RetailNext](http://retailnext.net/about-us/career-openings/) | Chicago, IL; San Francisco, CA; San Jose, CA |
 | [Riot Games](http://www.riotgames.com/careers) | Los Angeles, CA |


### PR DESCRIPTION
words from our persons responsible for applications:

ResearchGate is the professional network for researchers and scientists;
we connect the world of science and make research open to all. Check out
https://www.researchgate.net/careers#positions to find out who we're
looking for. Applying couldn't be easier: send your CV with Engineering
in the subject line to careers@researchgate.net and you'll be hearing
from us.