### PR TITLE
Casetext has moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Please note that it is not encouraged to blindly apply to every company on this 
 | [Capsule](https://www.capsulecares.com/about/) | New York, NY |
 | [Captain401](https://captain401.com/careers) | San Francisco, CA |
 | [Carbon](https://jobs.lever.co/carbon/) | Redwood City, CA |
-| [Casetext](https://casetext.com/jobs) | Palo Alto, CA |
+| [Casetext](https://casetext.com/jobs) | San Francisco, CA |
 | [Casper](https://boards.greenhouse.io/casper) | New York, NY |
 | [Catchpoint](http://www.catchpoint.com/about/careers/) | New York, NY |
 | [Centro](http://www.centro.net/careers) | Chicago, IL |


### PR DESCRIPTION
Casetext's HQ is now located in San Francisco.