### PR TITLE
removed NCMEC from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Please note that it is not encouraged to blindly apply to every company on this 
 | [ZenMate](https://zenmate.com/jobs/) | Berlin, Germany |
 | [Zillow](http://www.zillow.com/jobs/) | Irvine, CA; New York, NY; San Francisco, CA; Seattle, WA |
 | [ZocDoc](https://www.zocdoc.com/careers) | New York, NY |
-| [Zoosk](https://about.zoosk.com/en-us/careers/) | San Francisco, CA |
+| [Zoosk](https://about.zoosk.com/en/careers/) | San Francisco, CA |
 | [Zscaler](https://www.zscaler.com/careers/) | San Jose, CA |
 | [Zuora](https://www.zuora.com/about/careers/) | Foster City, CA; Remote |
 | [Zynga](https://www.zynga.com/careers) | San Francisco, CA |

--- a/README.md
+++ b/README.md
@@ -241,7 +241,6 @@ Please note that it is not encouraged to blindly apply to every company on this 
 | [MuleSoft](https://www.mulesoft.com/careers) | San Francisco, CA |
 | [Munchery](https://munchery.com/jobs/) | San Francisco, CA |
 | [Narrative Science](https://www.narrativescience.com/careers) | Chicago, IL |
-| [NCMEC](http://www.missingkids.com/Careers) | Alexandria, VA |
 | [Nervana Systems](http://www.nervanasys.com/careers/) | San Diego, CA |
 | [Nest](https://nest.com/careers/) | Kirkland, WA; Palo Alto, CA|
 | [New Relic](http://newrelic.com/about/careers) | San Francisco, CA |


### PR DESCRIPTION
It's not an easy application as it has a very lengthy form.

Please find the screenshots of the form below:-

![ncmec_form_](https://cloud.githubusercontent.com/assets/10476617/24680441/d02bacba-1945-11e7-9b9b-e3d1ab3b4e09.png)
![ncmec_form_2](https://cloud.githubusercontent.com/assets/10476617/24680442/d02bd1a4-1945-11e7-9621-a8ac902c2dc0.png)
![ncmec_form_3](https://cloud.githubusercontent.com/assets/10476617/24680443/d02cc24e-1945-11e7-993b-0de25594e649.png)
![ncmec_form_4](https://cloud.githubusercontent.com/assets/10476617/24680444/d02f683c-1945-11e7-9247-36d75c5ba22e.png)

NCMEC's application form is very lengthy when compared with any other company's form on easy application list. That's why I removed it from the list and raised this pull request.