### PR TITLE
Remove Tilt from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,6 @@ Please note that it is not encouraged to blindly apply to every company on this 
 | [Thumbtack](https://www.thumbtack.com/jobs) | San Francisco, CA |
 | [Tile](https://www.thetileapp.com/about#careers) | San Mateo, CA |
 | [Tillster](http://www.tillster.com/careers/) | Los Angeles, CA; San Diego, CA |
-| [Tilt](https://www.tilt.com/learn/jobs) | Austin, TX; San Francisco, CA |
 | [Tinder](https://www.gotinder.com/jobs) | Los Angeles, CA; Palo Alto, CA |
 | [Tint](https://www.tintup.com/jobs) | San Francisco, CA |
 | [TiVo](https://www.tivo.com/jobs) | Durham, NC; San Jose, CA |


### PR DESCRIPTION
Tilt has been [acquired by Airbnb](https://blog.tilt.com/) and will continue payouts from their platform until June 12, 2017. I think it is safe to say that they won't be hiring anyone in the near future.