### PR TITLE
Changed BitTiger's URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please note that it is not encouraged to blindly apply to every company on this 
 | [Bill.com](https://www.bill.com/about-us/careers/jobs/) | Palo Alto, CA |
 | [Bitly](https://bitly.com/pages/careers) | Denver, CO; San Francisco, CA; New York, NY  |
 | [Bitnami](https://bitnami.com/careers) | San Francisco, CA  |
-| [BitTiger](https://careers.bittiger.io/jobs/) | Santa Clara, CA |
+| [BitTiger](https://www.bittiger.io/jobs) | Santa Clara, CA |
 | [BitTorrent](http://www.bittorrent.com/company/about/jobs) | San Francisco, CA  |
 | [Blend Labs](https://blendlabs.com/careers/) | San Francisco, CA |
 | [Bloomz](https://www.bloomz.net/jobs/) | Redmond, WA |


### PR DESCRIPTION
The previous URL was pointing to an invalid link. It has been updated.